### PR TITLE
Add example.tex and CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: Check
+on: [push, pull_request]
+jobs:
+  texlive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install TeX Live
+        uses: zauguin/install-texlive@v3
+        with:
+          packages: >
+            tex latex-bin tools alphalph metalogo hyperref infwarerr
+            booktabs amsmath amsfonts colortbl hologo pdftexcmds iftex
+            kvoptions enumitem psnfss csquotes fancyvrb underscore metafont
+            ec hypdoc epstopdf-pkg
+      - run: tex intopdf.dtx
+      - run: pdflatex intopdf.dtx
+      - run: pdflatex intopdf.dtx
+      - run: pdflatex example.tex
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v3
+        with:
+          name: PDFs
+          path: "*.pdf"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.aux
+*.dvi
+*.glo
+*.hd
+*.idx
+*.log
+*.out
+*.sty
+
+example.pdf

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # intopdf [![CTAN](https://img.shields.io/badge/CTAN-intopdf-blue.svg?style=flat-square)](https://ctan.org/pkg/intopdf)
 
-> This package allows to embed non-PDF files (e.g., BibTex) into PDF with hyperlink.
+> This package allows embedding non-PDF files (e.g., BibTeX) into PDF with hyperlink.
 
 To install, you can run `tex intopdf.dtx` and copy the generated file `intopdf.sty` to a directory in the search path of your TeX installation.
 For quick evaluation, you can also rename `intopdf.dtx` to `intopdf.sty` and use that file directly.

--- a/example.tex
+++ b/example.tex
@@ -1,0 +1,5 @@
+\documentclass{article}
+\usepackage{intopdf}
+\begin{document}
+Please check the attached \attachandlink{README.md}[text/markdown]{README.md of intopdf package}{README.md}.
+\end{document}


### PR DESCRIPTION
To provide a minimal example for https://github.com/sumatrapdfreader/sumatrapdf/issues/1602#issuecomment-1690613031, I tried to create a small `example.pdf`. - I am aware that the documentation itself offers an embedding. However, non-LaTeX users might not be able to open `.dtx` files. Therefore, I created an example containing a `.md` file.

I also added a simple CI script.

I also fixed two minor things in README.md.